### PR TITLE
config: use https:// protocol in URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://blog.joinmastodon.org/"
+baseURL = "https://blog.joinmastodon.org/"
 languageCode = "en-us"
 title = "Official Mastodon Blog"
 paginate = 6


### PR DESCRIPTION
Fixes several internal links to use https:// instead of http://. This
matches with the current blog.joinmastodon.org deployment which enforces
HTTPS for all requests.
