### PR TITLE
fix: Fix repeated blog posts and featured image overflow on small viewports

### DIFF
--- a/themes/mastodon/layouts/_default/featured.html
+++ b/themes/mastodon/layouts/_default/featured.html
@@ -1,11 +1,11 @@
-<a href="{{ .RelPermalink }}" class="lg:col-span-3 group grid md:grid-cols-12 gap-y-16 gap-x-8 h-entry u-url" rel="bookmark">
-  <div class="w-full relative aspect-[3/2] overflow-hidden rounded-md bg-blurple-gradient col-span-12 md:col-span-6 shadow-lg ring-blurple-500 group-hover:ring-2">
+<a href="{{ .RelPermalink }}" class="lg:col-span-3 group grid md:grid-cols-12 gap-x-8 gap-y-4 md:gap-y-16 h-entry u-url" rel="bookmark">
+  <div class="w-full relative aspect-[3/2] overflow-hidden rounded-md bg-blurple-gradient md:col-span-6 shadow-lg ring-blurple-500 group-hover:ring-2">
     {{ with .Page.Resources.GetMatch "hero" }}
       <img src="{{ .RelPermalink }}" alt="" class="absolute w-full h-full object-cover" />
     {{ end }}
   </div>
 
-  <div class="col-span-12 md:col-span-6">
+  <div class="md:col-span-6">
     <div class="flex items-center gap-x-4 text-xs">
       <time class="text-gray-500 dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}">
         {{ .Date.Format "Jan 2, 2006" }}

--- a/themes/mastodon/layouts/index.html
+++ b/themes/mastodon/layouts/index.html
@@ -11,7 +11,7 @@
 			{{ .Render "summary" }}
 		{{ end }}
 		{{ partial "trunk-and-tidbits" . }}
-		{{ range after 1 $pages.Pages }}
+		{{ range after 3 $pages.Pages }}
 			{{ .Render "summary" }}
 		{{ end }}
 	{{ else }}


### PR DESCRIPTION
### Changes in this PR:

- Fixes repeated second and third posts on the blog's home grid (mea culpa, oversight from previous PR #36)
  
  | **Before** | **After** |
  |--------|--------|
  | ![image](https://github.com/user-attachments/assets/b531f971-9a42-4f64-9ac0-f98269adcb88) | ![image](https://github.com/user-attachments/assets/1549fc86-7388-4440-88a2-1fddb1807f6d) |

- Prevents hero image of the featured post to overflow the viewport on smaller screens. I also made the vertical spacing a bit more compact
  
  | **Before** | **After** |
  |--------|--------|
  | ![Screen Shot 2025-05-07 at 14 50 57](https://github.com/user-attachments/assets/c7613cb8-c846-46cb-93f6-f62ed08d8fc9) | ![Screen Shot 2025-05-07 at 14 51 15](https://github.com/user-attachments/assets/ecea2c54-bf2c-430d-891d-283d83b1c457) | 


